### PR TITLE
removing le logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ gem 'neat'
 gem 'autoprefixer-rails'
 
 gem 'newrelic_rpm'
-gem 'le'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,6 @@ GEM
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    le (2.6.2)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -337,7 +336,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy (~> 2.4.2)
-  le
   neat
   newrelic_rpm
   pg

--- a/README.md
+++ b/README.md
@@ -14,11 +14,4 @@ After you create the Vagrantfile run:
 bundle exec guard
 ```
 
-##### Logging
-[view logs](https://logentries.com/app/cacec443#id=9c562ff3-3cee-4162-a461-2fb7b3270b74&r=d&s=log_sets)
-
-To use logging with LE 
-```ruby
-Rails.logger.warn("Look at me, I'm a warning")
-```
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,5 +80,4 @@ Rails.application.configure do
   config.secret_key_base = ENV['SECRET_KEY_BASE']
   config.basic_auth_user = ENV['BASIC_AUTH_USERNAME']
   config.basic_auth_pass = ENV['BASIC_AUTH_PASSWORD']
-  Rails.logger = Le.new('633f6db7-ae80-47cb-8f48-7e3c5300ecd5', :debug => true, :local => true)
 end


### PR DESCRIPTION
Le logger is causing issues with our travis build. We aren't using it anywhere right now so I am taking it out. We can reevaluate cloud based logging services later on.
