### PR TITLE
update security headers

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -2,6 +2,8 @@
   config.hsts = { :max_age => 20.years.to_i, :include_subdomains => true }
   config.x_frame_options = 'DENY'
   config.x_content_type_options = 'nosniff'
-  config.x_xss_protection = { :value => 1, :mode => 'block' }
+  config.x_xss_protection = { value: 1, mode: 'block' }
   config.x_download_options = 'noopen'
+  config.x_permitted_cross_domain_policies = { value: 'none' }
+  config.csp = false
 end


### PR DESCRIPTION
Setting our CSP to false for the time being. https://github.com/twitter/secureheaders#content-security-policy-csp This will stop the console errors we have been seeing until we implement our CSP later.
